### PR TITLE
Change in equip item

### DIFF
--- a/BaseGame/EquipCommand.java
+++ b/BaseGame/EquipCommand.java
@@ -1,0 +1,20 @@
+package BaseGame;
+
+import UI.Commandable;
+import UI.MyGame;
+
+public class EquipCommand implements Commandable {
+
+	@Override
+	public void doCommand(MyGame g) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public boolean matchCommand(String s) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+}

--- a/BaseGame/Inventory.java
+++ b/BaseGame/Inventory.java
@@ -24,6 +24,8 @@ import UI.UserInterface;
 		Player can exit inventory view 
 		Prompt will confirm exit 
 		    If no confirmation given, loop until confirmation provided  
+		    
+		Add the selection of the inventory using a secondary command class that will consume equip the item using it's Inventory Array index.
  */
 
 public class Inventory {
@@ -99,6 +101,7 @@ public class Inventory {
 		
 		for(Item inv:Items)
 		{
+			s += "Slot#:" + Items.indexOf(inv) + sCR;
 			s += "Name: " + inv.getName() + sCR;
 			s += "Damage: " + inv.getDamage() + sCR;
 			s += "Remaining Uses: " + inv.getDamage() + sCR;


### PR DESCRIPTION
Currently the code for equipping an Item that leverages the command interface by typing "Equip 0".  Where 0 is the index number of the item in inventory.  The index number of the inventory Item is now displayed when typing "Inventory".  In order to make this work we will need to implement:

1.  Coding of the EqupCommand.docommand() method that will equip the item from the inventory based on the index.
2. The EquipCommand will need to be added to MyGame.
3.  The EquipCommand.docommand() will need to parse the user command to find the index integer of the item to equp.
4.  The EuqipCommand.docommand() will need to prompt the user to equip the item to an equipment slot: Head, hand(left | right) etc...